### PR TITLE
feat: Add Coverity static analysis workflows [RDKEMW-14544]

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+--container-architecture linux/amd64
+-W .github/workflows/native_full_build.yml

--- a/.github/workflows/coverity_component_full_scan.yml
+++ b/.github/workflows/coverity_component_full_scan.yml
@@ -65,6 +65,7 @@ jobs:
           export PATH=$PATH:/opt/coverity/bin
           set -x
           cd $GITHUB_WORKSPACE
+          mkdir -p config
           cov-configure --gcc
           cov-build --dir coverity_dir $BUILD_COMMAND
           cov-analyze --dir coverity_dir --one-tu-per-psf false --disable-spotbugs --aggressiveness-level low --enable DC.STRING_BUFFER --all

--- a/.github/workflows/coverity_component_full_scan.yml
+++ b/.github/workflows/coverity_component_full_scan.yml
@@ -1,0 +1,83 @@
+name: Coverity Full Analysis Scan
+
+# Reusable workflow — called by coverity_full_scan.yml.
+# Runs a full cov-build + cov-analyze + cov-commit-defects cycle.
+# Results are committed to the Coverity Connect server stream only;
+# nothing is posted back to any pull request.
+on:
+  workflow_call:
+    inputs:
+      buildCommand:
+        description: 'Build Command'
+        required: true
+        type: string
+      branchName:
+        description: 'Branch Name'
+        required: true
+        type: string
+      customSetup:
+        description: 'Custom setup commands'
+        required: false
+        type: string
+    secrets:
+      COVERITY_APIKEY:
+        required: true
+      ARTIFACTORY_USER_APIKEY:
+        required: true
+      # GITHUB_TOKENCM: cross-org token — required if customSetup clones private repos
+      GITHUB_TOKENCM:
+        required: false
+
+jobs:
+  coverity_full_scan:
+    runs-on: comcast-ubuntu-latest
+    container:
+      # TODO (org admin): provision vars.DOCKER_REGISTRY in rdkcentral org
+      image: ${{ vars.DOCKER_REGISTRY }}/rdk-docker/docker-rdk-coverity:1.0.7
+      credentials:
+        # TODO (org admin): provision vars.ARTIFACTORY_USER in rdkcentral org
+        username: ${{ vars.ARTIFACTORY_USER }}
+        password: ${{ secrets.ARTIFACTORY_USER_APIKEY }}
+
+    env:
+      # TODO (org admin): provision vars.COVERITY_URL and vars.COVERITY_USER in rdkcentral org
+      COVERITY_URL: ${{ vars.COVERITY_URL }}
+      COVERITY_USER: ${{ vars.COVERITY_USER }}
+      COVERITY_APIKEY: ${{ secrets.COVERITY_APIKEY }}
+      COVERITY_PROJECT_NAME: ${{ github.event.repository.name }}
+      COVERITY_STREAM_NAME: ${{ github.event.repository.name }}_${{ inputs.branchName }}
+      BUILD_COMMAND: ${{ inputs.buildCommand }}
+      GITHUB_TOKENCM: ${{ secrets.GITHUB_TOKENCM }}
+      COVERITY_UNSUPPORTED_COMPILER_INVOCATION: 1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Custom setup
+        if: ${{ inputs.customSetup }}
+        run: eval "${{ inputs.customSetup }}"
+
+      - name: Coverity Full Analysis Scan
+        run: |
+          export PATH=$PATH:/opt/coverity/bin
+          set -x
+          cd $GITHUB_WORKSPACE
+          cov-configure --gcc --config config/coverity_config.xml
+          cov-build --dir coverity_dir --config config/coverity_config.xml $BUILD_COMMAND
+          cov-analyze --dir coverity_dir --one-tu-per-psf false --disable-spotbugs --aggressiveness-level low --enable DC.STRING_BUFFER --all
+
+          max_retries=3
+          retries=0
+          retry_timeout_sec=30
+          success=false
+          while [ $retries -lt $max_retries ]; do
+            echo "Attempt $((retries + 1)) of $max_retries for cov-commit-defects"
+            if cov-commit-defects --dir coverity_dir --stream $COVERITY_STREAM_NAME \
+                --url $COVERITY_URL --user $COVERITY_USER --password $COVERITY_APIKEY; then
+              success=true
+              break
+            fi
+            retries=$((retries + 1))
+            sleep $((retries * retry_timeout_sec))
+          done
+          $success || { echo "cov-commit-defects failed after $max_retries attempts"; exit 1; }

--- a/.github/workflows/coverity_component_full_scan.yml
+++ b/.github/workflows/coverity_component_full_scan.yml
@@ -65,8 +65,8 @@ jobs:
           export PATH=$PATH:/opt/coverity/bin
           set -x
           cd $GITHUB_WORKSPACE
-          cov-configure --gcc --config config/coverity_config.xml
-          cov-build --dir coverity_dir --config config/coverity_config.xml $BUILD_COMMAND
+          cov-configure --gcc
+          cov-build --dir coverity_dir $BUILD_COMMAND
           cov-analyze --dir coverity_dir --one-tu-per-psf false --disable-spotbugs --aggressiveness-level low --enable DC.STRING_BUFFER --all
 
           max_retries=3

--- a/.github/workflows/coverity_component_full_scan.yml
+++ b/.github/workflows/coverity_component_full_scan.yml
@@ -28,6 +28,9 @@ on:
       GITHUB_TOKENCM:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   coverity_full_scan:
     runs-on: comcast-ubuntu-latest

--- a/.github/workflows/coverity_component_incremental_scan.yml
+++ b/.github/workflows/coverity_component_incremental_scan.yml
@@ -34,6 +34,10 @@ on:
       GITHUB_TOKENCM:
         required: false
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   coverity_incremental_scan:
     runs-on: comcast-ubuntu-latest

--- a/.github/workflows/coverity_component_incremental_scan.yml
+++ b/.github/workflows/coverity_component_incremental_scan.yml
@@ -62,6 +62,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ format('refs/pull/{0}/merge', inputs.pullRequestNumber) }}
 
       - name: Custom setup
         if: ${{ inputs.customSetup }}
@@ -71,12 +73,30 @@ jobs:
 
       - name: Get Pull Request Changeset
         id: changeset
-        uses: jitterbit/get-changed-files@v1
-        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pull_number = Number('${{ inputs.pullRequestNumber }}');
+            if (!Number.isInteger(pull_number) || pull_number <= 0) {
+              core.setFailed('Invalid pullRequestNumber input.');
+              return;
+            }
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+              per_page: 100
+            });
+            const addedModified = files
+              .filter((file) => file.status === 'added' || file.status === 'modified')
+              .map((file) => file.filename)
+              .join('\n');
+            core.setOutput('added_modified', addedModified);
 
       - name: Coverity Incremental Analysis Scan
         id: incremental_scan
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && steps.changeset.outputs.added_modified != '' }}
+        if: ${{ steps.changeset.outputs.added_modified != '' }}
         env:
           CHANGED_FILES_RAW: ${{ steps.changeset.outputs.added_modified }}
         run: |
@@ -89,7 +109,7 @@ jobs:
           cov-run-desktop --dir coverity_dir \
             --url $COVERITY_URL --user $COVERITY_USER --password $COVERITY_APIKEY \
             --stream $COVERITY_STREAM_NAME \
-            --build $BUILD_COMMAND
+            --build "$BUILD_COMMAND"
           # Phase 2: analyze changed files only, compare against stream baseline
           # --exit1-if-defects true: workflow fails on new defects (maintainers can bypass
           #   via GitHub branch protection "Allow specified actors to bypass required pull requests")

--- a/.github/workflows/coverity_component_incremental_scan.yml
+++ b/.github/workflows/coverity_component_incremental_scan.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pull_number = Number('${{ inputs.pullRequestNumber }}');
+            const pull_number = Number(${{ toJSON(inputs.pullRequestNumber) }});
             if (!Number.isInteger(pull_number) || pull_number <= 0) {
               core.setFailed('Invalid pullRequestNumber input.');
               return;
@@ -89,7 +89,7 @@ jobs:
               per_page: 100
             });
             const addedModified = files
-              .filter((file) => file.status === 'added' || file.status === 'modified')
+              .filter((file) => file.status === 'added' || file.status === 'modified' || file.status === 'renamed')
               .map((file) => file.filename)
               .join('\n');
             core.setOutput('added_modified', addedModified);

--- a/.github/workflows/coverity_component_incremental_scan.yml
+++ b/.github/workflows/coverity_component_incremental_scan.yml
@@ -1,0 +1,108 @@
+name: Coverity Incremental Analysis Scan
+
+# Reusable workflow — called by coverity_incremental_scan.yml.
+# Runs cov-run-desktop against changed files only and posts findings
+# as pull request comments via synopsys-sig/coverity-report-output-v7-json.
+on:
+  workflow_call:
+    inputs:
+      pullRequestNumber:
+        description: 'Pull Request Number'
+        required: true
+        type: string
+      buildCommand:
+        description: 'Build Command'
+        required: true
+        type: string
+      branchName:
+        description: 'Branch Name (target/base branch)'
+        required: true
+        type: string
+      customSetup:
+        description: 'Custom setup commands'
+        required: false
+        type: string
+    secrets:
+      COVERITY_APIKEY:
+        required: true
+      ARTIFACTORY_USER_APIKEY:
+        required: true
+      # GITHUB_TOKEN: used to post PR feedback comments
+      GITHUB_TOKEN:
+        required: true
+      # GITHUB_TOKENCM: cross-org token — required if customSetup clones private repos
+      GITHUB_TOKENCM:
+        required: false
+
+jobs:
+  coverity_incremental_scan:
+    runs-on: comcast-ubuntu-latest
+    container:
+      # TODO (org admin): provision vars.DOCKER_REGISTRY in rdkcentral org
+      image: ${{ vars.DOCKER_REGISTRY }}/rdk-docker/docker-rdk-coverity:1.0.7
+      credentials:
+        # TODO (org admin): provision vars.ARTIFACTORY_USER in rdkcentral org
+        username: ${{ vars.ARTIFACTORY_USER }}
+        password: ${{ secrets.ARTIFACTORY_USER_APIKEY }}
+
+    env:
+      # TODO (org admin): provision vars.COVERITY_URL and vars.COVERITY_USER in rdkcentral org
+      COVERITY_URL: ${{ vars.COVERITY_URL }}
+      COVERITY_USER: ${{ vars.COVERITY_USER }}
+      COVERITY_APIKEY: ${{ secrets.COVERITY_APIKEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      COVERITY_PROJECT_NAME: ${{ github.event.repository.name }}
+      COVERITY_STREAM_NAME: ${{ github.event.repository.name }}_${{ inputs.branchName }}
+      BUILD_COMMAND: ${{ inputs.buildCommand }}
+      COVERITY_UNSUPPORTED_COMPILER_INVOCATION: 1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Custom setup
+        if: ${{ inputs.customSetup }}
+        run: |
+          echo "customSetup: ${{ inputs.customSetup }}"
+          eval "${{ inputs.customSetup }}"
+
+      - name: Get Pull Request Changeset
+        id: changeset
+        uses: jitterbit/get-changed-files@v1
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Coverity Incremental Analysis Scan
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && steps.changeset.outputs.added_modified != '' }}
+        run: |
+          export PATH=$PATH:/opt/coverity/bin
+          set -x
+          cd $GITHUB_WORKSPACE
+          echo "Changed files: ${{ steps.changeset.outputs.added_modified }}"
+          # Phase 1: capture build into the coverity_dir intermediate database
+          cov-run-desktop --dir coverity_dir \
+            --url $COVERITY_URL --user $COVERITY_USER --password $COVERITY_APIKEY \
+            --stream $COVERITY_STREAM_NAME \
+            --build $BUILD_COMMAND
+          # Phase 2: analyze changed files only, compare against stream baseline
+          # --exit1-if-defects true: workflow fails on new defects (maintainers can bypass
+          #   via GitHub branch protection "Allow specified actors to bypass required pull requests")
+          cov-run-desktop --dir coverity_dir \
+            --url $COVERITY_URL --user $COVERITY_USER --password $COVERITY_APIKEY \
+            --stream $COVERITY_STREAM_NAME \
+            --present-in-reference false \
+            --ignore-uncapturable-inputs true \
+            --exit1-if-defects true \
+            --json-output-v7 coverity_dir/coverity-results.json \
+            --allow-suffix-match --set-new-defect-owner false \
+            ${{ steps.changeset.outputs.added_modified }}
+
+      # Post findings as PR comments — raw Coverity output, no custom formatting
+      - name: Coverity Pull Request Feedback
+        if: always()
+        uses: synopsys-sig/coverity-report-output-v7-json@v0.1.1
+        with:
+          json-file-path: coverity_dir/coverity-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverity-url: ${{ vars.COVERITY_URL }}
+          coverity-project-name: ${{ github.event.repository.name }}
+          coverity-username: ${{ vars.COVERITY_USER }}
+          coverity-password: ${{ secrets.COVERITY_APIKEY }}

--- a/.github/workflows/coverity_component_incremental_scan.yml
+++ b/.github/workflows/coverity_component_incremental_scan.yml
@@ -75,6 +75,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
 
       - name: Coverity Incremental Analysis Scan
+        id: incremental_scan
         if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && steps.changeset.outputs.added_modified != '' }}
         env:
           CHANGED_FILES_RAW: ${{ steps.changeset.outputs.added_modified }}
@@ -104,7 +105,7 @@ jobs:
 
       # Post findings as PR comments — raw Coverity output, no custom formatting
       - name: Coverity Pull Request Feedback
-        if: always()
+        if: ${{ always() && hashFiles('coverity_dir/coverity-results.json') != '' }}
         uses: synopsys-sig/coverity-report-output-v7-json@v0.1.1
         with:
           json-file-path: coverity_dir/coverity-results.json

--- a/.github/workflows/coverity_component_incremental_scan.yml
+++ b/.github/workflows/coverity_component_incremental_scan.yml
@@ -72,11 +72,14 @@ jobs:
 
       - name: Coverity Incremental Analysis Scan
         if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && steps.changeset.outputs.added_modified != '' }}
+        env:
+          CHANGED_FILES_RAW: ${{ steps.changeset.outputs.added_modified }}
         run: |
           export PATH=$PATH:/opt/coverity/bin
           set -x
           cd $GITHUB_WORKSPACE
-          echo "Changed files: ${{ steps.changeset.outputs.added_modified }}"
+          echo "Changed files: $CHANGED_FILES_RAW"
+          mapfile -t changed_files <<< "$CHANGED_FILES_RAW"
           # Phase 1: capture build into the coverity_dir intermediate database
           cov-run-desktop --dir coverity_dir \
             --url $COVERITY_URL --user $COVERITY_USER --password $COVERITY_APIKEY \
@@ -93,7 +96,7 @@ jobs:
             --exit1-if-defects true \
             --json-output-v7 coverity_dir/coverity-results.json \
             --allow-suffix-match --set-new-defect-owner false \
-            ${{ steps.changeset.outputs.added_modified }}
+            "${changed_files[@]}"
 
       # Post findings as PR comments — raw Coverity output, no custom formatting
       - name: Coverity Pull Request Feedback

--- a/.github/workflows/coverity_component_incremental_scan.yml
+++ b/.github/workflows/coverity_component_incremental_scan.yml
@@ -89,7 +89,7 @@ jobs:
               per_page: 100
             });
             const addedModified = files
-              .filter((file) => file.status === 'added' || file.status === 'modified' || file.status === 'renamed')
+              .filter((file) => ['added', 'modified', 'renamed'].includes(file.status))
               .map((file) => file.filename)
               .join('\n');
             core.setOutput('added_modified', addedModified);

--- a/.github/workflows/coverity_full_scan.yml
+++ b/.github/workflows/coverity_full_scan.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main, develop, '+([0-9])\.+([0-9])\.x-maintenance' ]
     paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
 
+permissions:
+  contents: read
+
 jobs:
   call-coverity-full-scan:
     uses: ./.github/workflows/coverity_component_full_scan.yml

--- a/.github/workflows/coverity_full_scan.yml
+++ b/.github/workflows/coverity_full_scan.yml
@@ -1,0 +1,21 @@
+name: Coverity Full Scan
+
+# Triggers on merges to primary branches.
+# Results committed to Coverity Connect server (maintainer-only access).
+# Nothing is posted back to any pull request.
+on:
+  push:
+    branches: [ main, develop, '+([0-9])\.+([0-9])\.x-maintenance' ]
+    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
+
+jobs:
+  call-coverity-full-scan:
+    uses: ./.github/workflows/coverity_component_full_scan.yml
+    with:
+      branchName: ${{ github.ref_name }}
+      buildCommand: sh cov_build.sh
+      customSetup: sh build_dependencies.sh
+    secrets:
+      COVERITY_APIKEY: ${{ secrets.COVERITY_APIKEY }}
+      ARTIFACTORY_USER_APIKEY: ${{ secrets.ARTIFACTORY_USER_APIKEY }}
+      GITHUB_TOKENCM: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/coverity_incremental_scan.yml
+++ b/.github/workflows/coverity_incremental_scan.yml
@@ -2,6 +2,7 @@ name: Coverity Incremental Scan
 
 permissions:
   contents: read
+  pull-requests: write
 
 # Triggers on pull requests targeting primary branches.
 # Scans only changed compilable source files.

--- a/.github/workflows/coverity_incremental_scan.yml
+++ b/.github/workflows/coverity_incremental_scan.yml
@@ -1,0 +1,30 @@
+name: Coverity Incremental Scan
+
+# Triggers on pull requests targeting primary branches.
+# Scans only changed compilable source files.
+# Findings are posted as pull request comments.
+# Merges are not blocked outright — maintainers can bypass via branch protection.
+on:
+  pull_request:
+    branches: [ main, develop, '+([0-9])\.+([0-9])\.x-maintenance' ]
+    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
+  workflow_dispatch:
+    inputs:
+      pullRequestNumber:
+        description: 'Pull Request Number'
+        required: true
+        type: string
+
+jobs:
+  call-coverity-incremental-scan:
+    uses: ./.github/workflows/coverity_component_incremental_scan.yml
+    with:
+      pullRequestNumber: ${{ github.event.inputs.pullRequestNumber || github.event.pull_request.number }}
+      branchName: ${{ github.event.pull_request.base.ref || github.ref_name }}
+      buildCommand: sh cov_build.sh
+      customSetup: sh build_dependencies.sh
+    secrets:
+      COVERITY_APIKEY: ${{ secrets.COVERITY_APIKEY }}
+      ARTIFACTORY_USER_APIKEY: ${{ secrets.ARTIFACTORY_USER_APIKEY }}
+      GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}
+      GITHUB_TOKENCM: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/coverity_incremental_scan.yml
+++ b/.github/workflows/coverity_incremental_scan.yml
@@ -1,5 +1,8 @@
 name: Coverity Incremental Scan
 
+permissions:
+  contents: read
+
 # Triggers on pull requests targeting primary branches.
 # Scans only changed compilable source files.
 # Findings are posted as pull request comments.

--- a/.github/workflows/native_full_build.yml
+++ b/.github/workflows/native_full_build.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main, '+([0-9])\.+([0-9])\.x-maintenance' ]
     paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp', 'CMakeLists.txt', 'cmake/**', 'build_dependencies.sh', 'cov_build.sh']
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/native_full_build.yml
+++ b/.github/workflows/native_full_build.yml
@@ -1,0 +1,32 @@
+name: Build Component in Native Environment
+
+on:
+  push:
+    branches: [ main, '+([0-9])\.+([0-9])\.x-maintenance' ]
+    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
+  pull_request:
+    branches: [ main, '+([0-9])\.+([0-9])\.x-maintenance' ]
+    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  native-build:
+    name: Build firebolt-cpp-transport in native environment
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: sh -x build_dependencies.sh
+
+      - name: Build
+        run: sh -x cov_build.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/native_full_build.yml
+++ b/.github/workflows/native_full_build.yml
@@ -3,10 +3,10 @@ name: Build Component in Native Environment
 on:
   push:
     branches: [ main, '+([0-9])\.+([0-9])\.x-maintenance' ]
-    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
+    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp', 'CMakeLists.txt', 'cmake/**', 'build_dependencies.sh', 'cov_build.sh']
   pull_request:
     branches: [ main, '+([0-9])\.+([0-9])\.x-maintenance' ]
-    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
+    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp', 'CMakeLists.txt', 'cmake/**', 'build_dependencies.sh', 'cov_build.sh']
 
 defaults:
   run:

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -27,7 +27,11 @@ apt-get install -y --no-install-recommends --fix-missing \
     curl wget git \
     python3-pip
 
-python3 -m pip install --break-system-packages gcovr
+if python3 -m pip help install | grep -q -- '--break-system-packages'; then
+    python3 -m pip install --break-system-packages gcovr
+else
+    python3 -m pip install gcovr
+fi
 
 # ---------------------------------------------------------------------------
 # 2. googletest

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# build_dependencies.sh — install all build dependencies for firebolt-cpp-transport
+#
+# Installs to the system prefix (/usr/local) and is intentionally idempotent:
+# running it multiple times is safe.  Mirrors the dep set and versions pinned in
+# .github/Dockerfile so that both the native CI image and the Coverity container
+# end up with an identical build environment.
+#
+# Usage: sh build_dependencies.sh
+#        (run as root, or with sudo, from any directory)
+set -x
+set -e
+
+DEPS_GOOGLETEST_V="1.15.2"
+DEPS_NLOHMANN_JSON_V="3.11.3"
+DEPS_JSON_SCHEMA_VALIDATOR_V="2.3.0"
+DEPS_WEBSOCKETPP_V="0.8.2"
+
+# ---------------------------------------------------------------------------
+# 1. System packages
+# ---------------------------------------------------------------------------
+apt-get update
+apt-get install -y --no-install-recommends --fix-missing \
+    build-essential ca-certificates \
+    cmake pkg-config clang-format \
+    libboost-all-dev \
+    curl wget git \
+    python3-pip
+
+pip install gcovr || pip3 install gcovr
+
+# ---------------------------------------------------------------------------
+# 2. googletest
+# ---------------------------------------------------------------------------
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+dir="googletest-${DEPS_GOOGLETEST_V}"
+curl -sL "https://github.com/google/googletest/releases/download/v${DEPS_GOOGLETEST_V}/${dir}.tar.gz" \
+    | tar xzf - -C "$WORK_DIR"
+cmake -B "$WORK_DIR/build/${dir}" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      "$WORK_DIR/${dir}"
+cmake --build "$WORK_DIR/build/${dir}" --target install
+
+# ---------------------------------------------------------------------------
+# 3. nlohmann/json
+# ---------------------------------------------------------------------------
+dir="nlohmann-json-${DEPS_NLOHMANN_JSON_V}"
+git clone --depth 1 --branch "v${DEPS_NLOHMANN_JSON_V}" \
+    "https://github.com/nlohmann/json" "$WORK_DIR/${dir}"
+cmake -B "$WORK_DIR/build/${dir}" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      -DJSON_BuildTests=OFF \
+      "$WORK_DIR/${dir}"
+cmake --build "$WORK_DIR/build/${dir}" --target install
+
+# ---------------------------------------------------------------------------
+# 4. json-schema-validator
+# ---------------------------------------------------------------------------
+dir="json-schema-validator-${DEPS_JSON_SCHEMA_VALIDATOR_V}"
+curl -sL "https://github.com/pboettch/json-schema-validator/archive/refs/tags/${DEPS_JSON_SCHEMA_VALIDATOR_V}.tar.gz" \
+    | tar xzf - -C "$WORK_DIR"
+cmake -B "$WORK_DIR/build/${dir}" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      -DJSON_VALIDATOR_BUILD_TESTS=OFF \
+      -DJSON_VALIDATOR_BUILD_EXAMPLES=OFF \
+      "$WORK_DIR/${dir}"
+cmake --build "$WORK_DIR/build/${dir}" --target install
+
+# ---------------------------------------------------------------------------
+# 5. websocketpp (header-only, cmake install registers package config)
+# ---------------------------------------------------------------------------
+dir="websocketpp-${DEPS_WEBSOCKETPP_V}"
+curl -sL "https://github.com/zaphoyd/websocketpp/archive/refs/tags/${DEPS_WEBSOCKETPP_V}.tar.gz" \
+    | tar xzf - -C "$WORK_DIR"
+cmake -B "$WORK_DIR/build/${dir}" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTS=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      "$WORK_DIR/${dir}"
+cmake --build "$WORK_DIR/build/${dir}" --target install

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -27,7 +27,7 @@ apt-get install -y --no-install-recommends --fix-missing \
     curl wget git \
     python3-pip
 
-pip install gcovr || pip3 install gcovr
+python3 -m pip install --break-system-packages gcovr
 
 # ---------------------------------------------------------------------------
 # 2. googletest

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# cov_build.sh — configure and build firebolt-cpp-transport
+#
+# Run from the repo root after build_dependencies.sh has prepared the
+# environment.  Produces a Debug build with tests enabled so that
+# Coverity can intercept the full compilation including test code.
+#
+# Usage: sh cov_build.sh
+set -x
+set -e
+
+GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-${PWD}}"
+cd "${GITHUB_WORKSPACE}"
+
+cmake -B build -S . \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DENABLE_TESTS=ON
+
+cmake --build build --parallel

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -12,8 +12,8 @@ set -e
 GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-${PWD}}"
 cd "${GITHUB_WORKSPACE}"
 
-cmake -B build -S . \
+cmake -B build-dev -S . \
     -DCMAKE_BUILD_TYPE=Debug \
     -DENABLE_TESTS=ON
 
-cmake --build build --parallel
+cmake --build build-dev --parallel

--- a/coverity_local.sh
+++ b/coverity_local.sh
@@ -31,7 +31,8 @@ if [[ -z "$IMAGE" ]]; then
 fi
 
 docker run --rm \
-  --user "$(id -u):$(id -g)" \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
   -v "$(pwd):/workspace" \
   -w /workspace \
   "$IMAGE" \
@@ -60,6 +61,9 @@ docker run --rm \
     # Emit HTML report for browsing
     mkdir -p coverity_html
     cov-format-errors --dir coverity_dir --html-output coverity_html
+
+    # Keep generated outputs writable by the invoking host user
+    chown -R "${HOST_UID}:${HOST_GID}" coverity_dir coverity_html || true
 
     echo ""
     echo "HTML report: coverity_html/index.html"

--- a/coverity_local.sh
+++ b/coverity_local.sh
@@ -10,8 +10,8 @@
 #   docker pull <DOCKER_REGISTRY>/rdk-docker/docker-rdk-coverity:1.0.7
 #
 # Usage:
-#   sh coverity_local.sh
-#   sh coverity_local.sh --image <full-image-ref>   # override image
+#   bash coverity_local.sh
+#   ./coverity_local.sh --image <full-image-ref>   # override image
 set -e
 
 IMAGE="${COVERITY_IMAGE:-}"

--- a/coverity_local.sh
+++ b/coverity_local.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# coverity_local.sh — run a Coverity static analysis scan on your local machine
+#
+# Runs cov-build + cov-analyze inside the same Docker image used by CI.
+# Results are written to ./coverity_dir/ and an HTML report to ./coverity_html/.
+# No Coverity Connect server connection is made — raw tool output only.
+#
+# Prerequisites:
+#   docker login <DOCKER_REGISTRY> -u <user> -p <apikey>
+#   docker pull <DOCKER_REGISTRY>/rdk-docker/docker-rdk-coverity:1.0.7
+#
+# Usage:
+#   sh coverity_local.sh
+#   sh coverity_local.sh --image <full-image-ref>   # override image
+set -e
+
+IMAGE="${COVERITY_IMAGE:-}"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --image) IMAGE="$2"; shift 2;;
+    *) echo "Unknown option: $1" >&2; exit 1;;
+  esac
+done
+
+if [[ -z "$IMAGE" ]]; then
+  if [[ -z "${DOCKER_REGISTRY:-}" ]]; then
+    echo "ERROR: set DOCKER_REGISTRY or pass --image <full-image-ref>" >&2
+    exit 1
+  fi
+  IMAGE="${DOCKER_REGISTRY}/rdk-docker/docker-rdk-coverity:1.0.7"
+fi
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$(pwd):/workspace" \
+  -w /workspace \
+  "$IMAGE" \
+  bash -c '
+    set -ex
+    export PATH=$PATH:/opt/coverity/bin
+
+    # Install build dependencies
+    sh build_dependencies.sh
+
+    # Capture build
+    cov-configure --gcc --config config/coverity_config.xml
+    cov-build --dir coverity_dir --config config/coverity_config.xml sh cov_build.sh
+
+    # Analyze — same checker set as CI full scan
+    cov-analyze --dir coverity_dir \
+      --one-tu-per-psf false \
+      --disable-spotbugs \
+      --aggressiveness-level low \
+      --enable DC.STRING_BUFFER \
+      --all
+
+    # Emit raw text summary to stdout
+    cov-format-errors --dir coverity_dir --emacs-style
+
+    # Emit HTML report for browsing
+    mkdir -p coverity_html
+    cov-format-errors --dir coverity_dir --html-output coverity_html
+
+    echo ""
+    echo "HTML report: coverity_html/index.html"
+    echo "Raw database: coverity_dir/"
+  '

--- a/coverity_local.sh
+++ b/coverity_local.sh
@@ -43,8 +43,8 @@ docker run --rm \
     sh build_dependencies.sh
 
     # Capture build
-    cov-configure --gcc --config config/coverity_config.xml
-    cov-build --dir coverity_dir --config config/coverity_config.xml sh cov_build.sh
+    cov-configure --gcc
+    cov-build --dir coverity_dir sh cov_build.sh
 
     # Analyze — same checker set as CI full scan
     cov-analyze --dir coverity_dir \


### PR DESCRIPTION
## Summary

Adds Coverity static analysis integration to `firebolt-cpp-transport` following the established RDK-E pattern, adapted for the rdkcentral org.

Implements both GitHub Actions CI integration (full scan on push, incremental scan on PRs) and a local developer workflow.

## Files Added

| File | Purpose |
|---|---|
| `build_dependencies.sh` | Installs all build deps from source (mirrors `.github/Dockerfile`); idempotent; shared interface contract for both CI and Coverity |
| `cov_build.sh` | `cmake` configure + build; interface contract with the Coverity capture step |
| `.github/workflows/native_full_build.yml` | Build verification CI; doubles as local `act` validation target |
| `.github/workflows/coverity_full_scan.yml` | Thin caller — full scan on push to `main`/`develop` |
| `.github/workflows/coverity_incremental_scan.yml` | Thin caller — incremental scan on PRs + `workflow_dispatch` (on-demand) |
| `.github/workflows/coverity_component_full_scan.yml` | Self-contained reusable full scan engine (local copy; no external dependency on `rdk-e/build_tools_workflows`) |
| `.github/workflows/coverity_component_incremental_scan.yml` | Self-contained reusable incremental scan engine; posts defect details as PR review comments |
| `coverity_local.sh` | Offline developer scan via Docker — no server required; outputs raw text + HTML to `coverity_html/` |
| `.actrc` | `act` convenience defaults for local native build validation |

## How It Works

**Full scan** (push to `main`/`develop`): `cov-configure` → `cov-build` (via `cov_build.sh`) → `cov-analyze` → `cov-commit-defects` to Coverity Central stream. Retries up to 3× on commit failure.

**Incremental scan** (PR): `cov-run-desktop` against the latest stream snapshot → JSON results → `synopsys-sig/coverity-report-output-v7-json` posts defect details as PR review comments. Job fails if new defects are found.

**Local** (`sh coverity_local.sh`): Same build + analyze pipeline inside the Coverity Docker image, outputs `coverity_html/` — no credentials or server access required.

## Testing

`act` local run passes (23s, `native_full_build.yml`):
```
✅ Build CPP Library - success
```

## Prerequisites (must be provisioned before CI runs)

> **Note for Code Central team**: this is an rdkcentral (open source) repo — coordinate via `#code_rdkcentral_support`.
> Contacts: stephen_barrett@comcast.com, Simon_Chung@comcast.com

- [ ] Coverity Central: create project `firebolt-cpp-transport` with streams `firebolt-cpp-transport_main` and `firebolt-cpp-transport_develop`
- [ ] Org var `COVERITY_URL` — Coverity Central server URL
- [ ] Org var `COVERITY_USER` — service account username
- [ ] Org secret `COVERITY_APIKEY` — service account API key
- [ ] Org var `DOCKER_REGISTRY` — Artifactory registry hostname
- [ ] Org var `ARTIFACTORY_USER` — Artifactory username
- [ ] Org secret `ARTIFACTORY_USER_APIKEY` — Artifactory API key
- [ ] `comcast-ubuntu-latest` runner available in rdkcentral org (confirm with Comcast GitHub DevOps team)
- [ ] `secrets.RDKCM_RDKE` — already exists ✅

## References

- Jira: RDKEMW-14544
- RDK-E Coverity guide: https://etwiki.sys.comcast.net/display/RDKDocumentation/Setting+up+Coverity+for+RDK-E+in+the+GitHub+Actions+workflow
- rdkcentral Coverity wiki: https://wiki.rdkcentral.com/pages/viewpage.action?pageId=383457070
- Support Slack: `#code_rdkcentral_support`