### PR TITLE
ci: add auto-sync workflow to promote develop to main

### DIFF
--- a/.github/workflows/sync-develop-to-main.yml
+++ b/.github/workflows/sync-develop-to-main.yml
@@ -1,0 +1,106 @@
+# Sync develop → main
+#
+# Runs automatically on every merge to develop, and on demand via workflow_dispatch.
+# On a clean merge: pushes directly to main.
+# On a conflict: opens a PR instead so it can be resolved with human eyes.
+#
+# To adapt for another repo, change SOURCE_BRANCH / TARGET_BRANCH below.
+# When a shared org workflow repo exists, these become reusable workflow inputs.
+
+name: Sync develop to main
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+env:
+  SOURCE_BRANCH: develop
+  TARGET_BRANCH: main
+  GIT_USER_NAME: github-actions[bot]
+  GIT_USER_EMAIL: github-actions[bot]@users.noreply.github.com
+
+jobs:
+  sync:
+    name: Merge develop to main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "${{ env.GIT_USER_NAME }}"
+          git config user.email "${{ env.GIT_USER_EMAIL }}"
+
+      - name: Check if sync is needed
+        id: check
+        run: |
+          git fetch origin \
+            "refs/heads/${{ env.SOURCE_BRANCH }}:refs/remotes/origin/${{ env.SOURCE_BRANCH }}" \
+            "refs/heads/${{ env.TARGET_BRANCH }}:refs/remotes/origin/${{ env.TARGET_BRANCH }}"
+          if git merge-base --is-ancestor "origin/${{ env.SOURCE_BRANCH }}" "origin/${{ env.TARGET_BRANCH }}"; then
+            echo "already_synced=true" >> "$GITHUB_OUTPUT"
+            echo "${{ env.TARGET_BRANCH }} already contains all commits from ${{ env.SOURCE_BRANCH }} — nothing to do."
+          else
+            echo "already_synced=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attempt merge
+        if: steps.check.outputs.already_synced == 'false'
+        id: merge
+        run: |
+          git checkout -B "${{ env.TARGET_BRANCH }}" "origin/${{ env.TARGET_BRANCH }}"
+
+          if git merge --no-edit "origin/${{ env.SOURCE_BRANCH }}"; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            git merge --abort || true
+          fi
+
+      - name: Push merged result
+        if: steps.check.outputs.already_synced == 'false' && steps.merge.outputs.conflict == 'false'
+        run: |
+          git push origin "${{ env.TARGET_BRANCH }}"
+          echo "Pushed ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} successfully."
+
+      - name: Open PR on conflict
+        if: steps.check.outputs.already_synced == 'false' && steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+        run: |
+          PR_BRANCH="auto-sync/${{ env.SOURCE_BRANCH }}-to-${{ env.TARGET_BRANCH }}"
+
+          # Create or reset the conflict-resolution branch from source
+          git checkout -B "$PR_BRANCH" "origin/${{ env.SOURCE_BRANCH }}"
+          git push origin "$PR_BRANCH" --force
+
+          # Open a PR if one doesn't already exist
+          EXISTING=$(gh pr list --base "${{ env.TARGET_BRANCH }}" --head "$PR_BRANCH" --json number --jq '.[0].number')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --base "${{ env.TARGET_BRANCH }}" \
+              --head "$PR_BRANCH" \
+              --title "chore: auto-sync ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} (conflict)" \
+              --body "$(cat <<'EOF'
+          Automatic sync of \`${{ env.SOURCE_BRANCH }}\` → \`${{ env.TARGET_BRANCH }}\` detected a merge conflict and could not push directly.
+
+          **Action required:** resolve the conflicts in this PR, then merge it.
+
+          _Triggered by: ${{ github.sha }} on ${{ github.ref_name }}_
+          EOF
+          )"
+            echo "PR opened for manual conflict resolution."
+          else
+            echo "PR #$EXISTING already open — skipping creation."
+          fi
+          exit 1  # Fail the job so the conflict is visible in the Actions UI

--- a/.github/workflows/sync-develop-to-main.yml
+++ b/.github/workflows/sync-develop-to-main.yml
@@ -15,6 +15,10 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: sync-${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 env:
   SOURCE_BRANCH: develop
   TARGET_BRANCH: main
@@ -69,38 +73,59 @@ jobs:
 
       - name: Push merged result
         if: steps.check.outputs.already_synced == 'false' && steps.merge.outputs.conflict == 'false'
+        id: push_merged
         run: |
-          git push origin "${{ env.TARGET_BRANCH }}"
-          echo "Pushed ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} successfully."
+          if git push origin "${{ env.TARGET_BRANCH }}"; then
+            echo "push_failed=false" >> "$GITHUB_OUTPUT"
+            echo "Pushed ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} successfully."
+          else
+            echo "push_failed=true" >> "$GITHUB_OUTPUT"
+            echo "Direct push failed. Falling back to conflict PR path."
+          fi
 
       - name: Open PR on conflict
-        if: steps.check.outputs.already_synced == 'false' && steps.merge.outputs.conflict == 'true'
+        if: steps.check.outputs.already_synced == 'false' && (steps.merge.outputs.conflict == 'true' || steps.push_merged.outputs.push_failed == 'true')
         env:
           GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: |
           PR_BRANCH="auto-sync/${{ env.SOURCE_BRANCH }}-to-${{ env.TARGET_BRANCH }}"
-
-          # Create or reset the conflict-resolution branch from source
-          git checkout -B "$PR_BRANCH" "origin/${{ env.SOURCE_BRANCH }}"
-          git push origin "$PR_BRANCH" --force
+          REASON="merge conflict"
+          if [ "${{ steps.merge.outputs.conflict }}" != "true" ]; then
+            REASON="direct push failure"
+          fi
 
           # Open a PR if one doesn't already exist
           EXISTING=$(gh pr list --base "${{ env.TARGET_BRANCH }}" --head "$PR_BRANCH" --json number --jq '.[0].number')
           if [ -z "$EXISTING" ]; then
-            gh pr create \
-              --base "${{ env.TARGET_BRANCH }}" \
-              --head "$PR_BRANCH" \
-              --title "chore: auto-sync ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} (conflict)" \
-              --body "$(cat <<'EOF'
-          Automatic sync of \`${{ env.SOURCE_BRANCH }}\` → \`${{ env.TARGET_BRANCH }}\` detected a merge conflict and could not push directly.
+            PUSH_BRANCH="$PR_BRANCH"
+
+            # If the canonical branch already exists (without an open PR), use a unique branch
+            # to avoid force-pushing over potential in-progress manual work.
+            if git ls-remote --exit-code --heads origin "$PR_BRANCH" >/dev/null 2>&1; then
+              PUSH_BRANCH="$PR_BRANCH-${GITHUB_RUN_ID}"
+            fi
+
+            git checkout -B "$PUSH_BRANCH" "origin/${{ env.SOURCE_BRANCH }}"
+            git push origin "$PUSH_BRANCH"
+
+            PR_BODY=$(cat <<EOF
+          Automatic sync of \`${{ env.SOURCE_BRANCH }}\` → \`${{ env.TARGET_BRANCH }}\` could not complete via direct workflow push.
 
           **Action required:** resolve the conflicts in this PR, then merge it.
 
+          **Detected reason:** ${REASON}
+
           _Triggered by: ${{ github.sha }} on ${{ github.ref_name }}_
           EOF
-          )"
+          )
+
+            gh pr create \
+              --base "${{ env.TARGET_BRANCH }}" \
+              --head "$PUSH_BRANCH" \
+              --title "chore: auto-sync ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} ($REASON)" \
+              --body "$PR_BODY"
             echo "PR opened for manual conflict resolution."
           else
-            echo "PR #$EXISTING already open — skipping creation."
+            echo "PR #$EXISTING already open — leaving branch untouched."
           fi
           exit 1  # Fail the job so the conflict is visible in the Actions UI


### PR DESCRIPTION
## Summary
This PR adds automated branch promotion from `develop` to `main`.

When code is merged to `develop`, a GitHub Actions workflow attempts to merge `develop` into `main` automatically.

## Why
- Keep `main` continuously aligned with `develop`
- Reduce manual promotion overhead
- Standardize promotion behavior across repositories

## What This Changes
- Adds a new workflow:
  - `.github/workflows/sync-develop-to-main.yml`
- Workflow triggers:
  - `push` to `develop`
  - `workflow_dispatch` (manual run)
- Sync behavior:
  - Skip if `main` already contains `develop`
  - Merge `develop` into `main`
  - Push directly if merge is clean
  - Open a PR for manual resolution if there is a merge conflict
  - Fall back to PR flow if direct push fails
- Adds concurrency protection to prevent overlapping runs
- Avoids force-pushing over an existing conflict-resolution branch

## Safety and Operational Behavior
- Uses existing secret `SEMANTIC_RELEASE_TOKEN` for authenticated push/PR operations
- Preserves existing open conflict PR branch (no overwrite)
- Fails workflow intentionally when manual intervention is required so it is visible in Actions UI

## First-Run Expectation
Because of historical branch divergence, the first run may open a conflict PR.  
After that one-time reconciliation, ongoing runs should generally be clean.

## Validation Performed
- Local workflow execution with `act` for control-flow validation
- Verified branch comparison, merge attempt, and conflict path
- Confirmed race protection and push-failure fallback behavior

## Scope
This PR is intentionally limited to workflow automation only.
No application/runtime code paths are changed.